### PR TITLE
1.8.x Update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 apply plugin: 'forge'
 
 minecraft {
-	version = "1.7.2-10.12.1.1060"
+	version = "1.8-11.14.1.1334"
 }
 
 group = project.projectDir.name.toLowerCase()

--- a/java/squeek/speedometer/HudSpeedometer.java
+++ b/java/squeek/speedometer/HudSpeedometer.java
@@ -96,8 +96,8 @@ public class HudSpeedometer extends Gui
 		String strCurrentSpeed = drawCurrentSpeed ? String.format(numFormatString + "%s", ModConfig.SPEED_UNIT.convertTo(this.currentSpeed), unitString) : null;
 		String strJumpSpeedChanged = !this.wasFirstJump ? String.format("%+.2f (%+.1f%%)", ModConfig.SPEED_UNIT.convertTo(this.jumpSpeedChanged), ((this.percentJumpSpeedChanged) * 100.0F)) : String.format(numFormatString, ModConfig.SPEED_UNIT.convertTo(this.firstJumpSpeed));
 
-		int width = HudSpeedometer.mc.fontRenderer.getStringWidth(strCurrentSpeed);
-		int height = HudSpeedometer.mc.fontRenderer.FONT_HEIGHT;
+		int width = HudSpeedometer.mc.fontRendererObj.getStringWidth(strCurrentSpeed);
+		int height = HudSpeedometer.mc.fontRendererObj.FONT_HEIGHT;
 		int padding = ModConfig.SPEEDOMETER_PADDING.getInt();
 		int margin = ModConfig.SPEEDOMETER_MARGIN.getInt();
 		int xPos = ModConfig.SPEEDOMETER_XPOS.getInt() + margin;
@@ -122,7 +122,7 @@ public class HudSpeedometer extends Gui
 
 		if (drawJumpSpeedChanged && ModConfig.LAST_JUMP_INFO_ENABLED.getBoolean(true))
 		{
-			int stringWidth = HudSpeedometer.mc.fontRenderer.getStringWidth(strJumpSpeedChanged);
+			int stringWidth = HudSpeedometer.mc.fontRendererObj.getStringWidth(strJumpSpeedChanged);
 			int floatingXPos = xPos + (width / 2) - stringWidth / 2;
 
 			// dont let it go offscreen
@@ -132,22 +132,22 @@ public class HudSpeedometer extends Gui
 				floatingXPos = scaledresolution.getScaledWidth() - stringWidth - margin;
 
 			int floatingYPos = yPos;
-			int floatingYPosOffset = (int) (HudSpeedometer.mc.fontRenderer.FONT_HEIGHT * 1.75F);
+			int floatingYPosOffset = (int) (HudSpeedometer.mc.fontRendererObj.FONT_HEIGHT * 1.75F);
 			int floatingYPosOffsetDirection = (floatingYPos - floatingYPosOffset < 0) ? 1 : -1;
 			floatingYPos += floatingYPosOffsetDirection * floatingYPosOffset;
 
 			if (ModConfig.LAST_JUMP_INFO_FLOAT_ENABLED.getBoolean(true))
 			{
 				float percentJumpInfoElapsed = lastJumpInfoTimeRemaining() / (float) (ModConfig.LAST_JUMP_INFO_DURATION.getDouble(ModConfig.LAST_JUMP_INFO_DURATION_DEFAULT));
-				floatingYPos += floatingYPosOffsetDirection * (percentJumpInfoElapsed * HudSpeedometer.mc.fontRenderer.FONT_HEIGHT * 4);
+				floatingYPos += floatingYPosOffsetDirection * (percentJumpInfoElapsed * HudSpeedometer.mc.fontRendererObj.FONT_HEIGHT * 4);
 			}
 			int color = this.wasFirstJump ? 0x2b7bff : (this.jumpSpeedChanged == 0 ? 14737632 : (this.jumpSpeedChanged > 0 ? 1481216 : 10092544));
-			this.drawString(HudSpeedometer.mc.fontRenderer, strJumpSpeedChanged, floatingXPos, floatingYPos, color);
+			this.drawString(HudSpeedometer.mc.fontRendererObj, strJumpSpeedChanged, floatingXPos, floatingYPos, color);
 		}
 
 		if (drawCurrentSpeed)
 		{
-			this.drawString(HudSpeedometer.mc.fontRenderer, strCurrentSpeed, xPos, yPos, 14737632);
+			this.drawString(HudSpeedometer.mc.fontRendererObj, strCurrentSpeed, xPos, yPos, 14737632);
 		}
 	}
 

--- a/java/squeek/speedometer/HudSpeedometer.java
+++ b/java/squeek/speedometer/HudSpeedometer.java
@@ -7,8 +7,8 @@ import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.util.MathHelper;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
-import cpw.mods.fml.client.FMLClientHandler;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.client.FMLClientHandler;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class HudSpeedometer extends Gui
 {

--- a/java/squeek/speedometer/HudSpeedometer.java
+++ b/java/squeek/speedometer/HudSpeedometer.java
@@ -86,7 +86,7 @@ public class HudSpeedometer extends Gui
 			}
 		}
 		else
-			scaledresolution = new ScaledResolution(mc.gameSettings, mc.displayWidth, mc.displayHeight);
+			scaledresolution = new ScaledResolution(mc.getMinecraft(), mc.displayWidth, mc.displayHeight);
 
 		boolean drawCurrentSpeed = true;
 		boolean drawJumpSpeedChanged = lastJumpSpeed != 0 && showingLastJumpInfo();

--- a/java/squeek/speedometer/ModSpeedometer.java
+++ b/java/squeek/speedometer/ModSpeedometer.java
@@ -1,16 +1,16 @@
 package squeek.speedometer;
 
 import net.minecraftforge.common.MinecraftForge;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.Mod;
-import cpw.mods.fml.common.Mod.EventHandler;
-import cpw.mods.fml.common.Mod.Instance;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLInterModComms;
-import cpw.mods.fml.common.event.FMLPostInitializationEvent;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.Mod.Instance;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
+import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 @Mod(modid = ModInfo.MODID, version = ModInfo.VERSION)
 public class ModSpeedometer

--- a/java/squeek/speedometer/SpeedometerKeyHandler.java
+++ b/java/squeek/speedometer/SpeedometerKeyHandler.java
@@ -4,9 +4,9 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.KeyBinding;
 import org.lwjgl.input.Keyboard;
 import squeek.speedometer.gui.screen.ScreenSpeedometerSettings;
-import cpw.mods.fml.client.registry.ClientRegistry;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.common.gameevent.InputEvent.KeyInputEvent;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.InputEvent.KeyInputEvent;
 
 public class SpeedometerKeyHandler
 {

--- a/java/squeek/speedometer/gui/screen/GuiScreen.java
+++ b/java/squeek/speedometer/gui/screen/GuiScreen.java
@@ -6,8 +6,8 @@ import squeek.speedometer.gui.GuiEvent;
 import squeek.speedometer.gui.IGuiEventHandler;
 import squeek.speedometer.gui.IGuiHierarchical;
 import squeek.speedometer.gui.widget.IWidget;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
 public class GuiScreen extends net.minecraft.client.gui.GuiScreen implements IGuiHierarchical, IGuiEventHandler

--- a/java/squeek/speedometer/gui/screen/GuiScreen.java
+++ b/java/squeek/speedometer/gui/screen/GuiScreen.java
@@ -112,21 +112,24 @@ public class GuiScreen extends net.minecraft.client.gui.GuiScreen implements IGu
 	}
 
 	@Override
-	protected void mouseClicked(int mouseX, int mouseY, int type) throws IOException {
+	protected void mouseClicked(int mouseX, int mouseY, int type) throws IOException
+	{
 		for (IWidget child : this.children)
 			child.mouseClicked(mouseX, mouseY, type, isShiftKeyDown());
 		super.mouseClicked(mouseX, mouseY, type);
 	}
 
 	@Override
-	public void handleMouseInput() throws IOException {
+	public void handleMouseInput() throws IOException
+	{
 		for (IWidget child : this.children)
 			child.handleMouseInput();
 		super.handleMouseInput();
 	}
 
 	@Override
-	protected void keyTyped(char c, int i) throws IOException {
+	protected void keyTyped(char c, int i) throws IOException
+	{
 		for (IWidget child : this.children)
 		{
 			if (child.keyTyped(c, i))

--- a/java/squeek/speedometer/gui/screen/GuiScreen.java
+++ b/java/squeek/speedometer/gui/screen/GuiScreen.java
@@ -1,5 +1,6 @@
 package squeek.speedometer.gui.screen;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import squeek.speedometer.gui.GuiEvent;
@@ -111,24 +112,21 @@ public class GuiScreen extends net.minecraft.client.gui.GuiScreen implements IGu
 	}
 
 	@Override
-	protected void mouseClicked(int mouseX, int mouseY, int type)
-	{
+	protected void mouseClicked(int mouseX, int mouseY, int type) throws IOException {
 		for (IWidget child : this.children)
 			child.mouseClicked(mouseX, mouseY, type, isShiftKeyDown());
 		super.mouseClicked(mouseX, mouseY, type);
 	}
 
 	@Override
-	public void handleMouseInput()
-	{
+	public void handleMouseInput() throws IOException {
 		for (IWidget child : this.children)
 			child.handleMouseInput();
 		super.handleMouseInput();
 	}
 
 	@Override
-	protected void keyTyped(char c, int i)
-	{
+	protected void keyTyped(char c, int i) throws IOException {
 		for (IWidget child : this.children)
 		{
 			if (child.keyTyped(c, i))

--- a/java/squeek/speedometer/gui/screen/ScreenSpeedometerSettings.java
+++ b/java/squeek/speedometer/gui/screen/ScreenSpeedometerSettings.java
@@ -8,7 +8,7 @@ import squeek.speedometer.SpeedUnit;
 import squeek.speedometer.gui.GuiEvent;
 import squeek.speedometer.gui.IGuiHierarchical;
 import squeek.speedometer.gui.widget.*;
-import cpw.mods.fml.common.Loader;
+import net.minecraftforge.fml.common.Loader;
 
 public class ScreenSpeedometerSettings extends GuiScreen
 {

--- a/java/squeek/speedometer/gui/widget/WidgetButton.java
+++ b/java/squeek/speedometer/gui/widget/WidgetButton.java
@@ -56,7 +56,7 @@ public class WidgetButton extends WidgetBase
 	{
 		if (isEnabled() && isVisible() && isMouseInsideBounds(mouseX, mouseY))
 		{
-	        this.mc.getSoundHandler().playSound(PositionedSoundRecord.func_147674_a(new ResourceLocation("gui.button.press"), 1.0F));
+	        this.mc.getSoundHandler().playSound(PositionedSoundRecord.create(new ResourceLocation("gui.button.press"), 1.0F));
 			onClicked(type, isShiftKeyDown);
 		}
 		else

--- a/java/squeek/speedometer/gui/widget/WidgetLabel.java
+++ b/java/squeek/speedometer/gui/widget/WidgetLabel.java
@@ -39,7 +39,7 @@ public class WidgetLabel extends WidgetBase
 				y -= mc.fontRendererObj.FONT_HEIGHT / 2;
 			}
 			GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-			mc.fontRendererObj.drawString(this.text, x, y, this.color, this.drawShadow);
+			mc.fontRendererObj.func_175065_a(this.text, x, y, this.color, this.drawShadow);
 		}
 		super.drawForeground(mouseX, mouseY);
 	}

--- a/java/squeek/speedometer/gui/widget/WidgetLabel.java
+++ b/java/squeek/speedometer/gui/widget/WidgetLabel.java
@@ -14,14 +14,14 @@ public class WidgetLabel extends WidgetBase
 	{
 		super(parent, x, y);
 		this.text = text;
-		this.setSize(mc.fontRenderer.getStringWidth(this.text), mc.fontRenderer.FONT_HEIGHT);
+		this.setSize(mc.fontRendererObj.getStringWidth(this.text), mc.fontRendererObj.FONT_HEIGHT);
 	}
 
 	public WidgetLabel(IGuiHierarchical parent, int x, int y, String text, int color, boolean drawShadow)
 	{
 		super(parent, x, y);
 		this.text = text;
-		this.setSize(mc.fontRenderer.getStringWidth(this.text), mc.fontRenderer.FONT_HEIGHT);
+		this.setSize(mc.fontRendererObj.getStringWidth(this.text), mc.fontRendererObj.FONT_HEIGHT);
 		this.color = color;
 		this.drawShadow = drawShadow;
 	}
@@ -35,11 +35,11 @@ public class WidgetLabel extends WidgetBase
 			int y = this.y;
 			if (drawCentered)
 			{
-				x -= mc.fontRenderer.getStringWidth(this.text) / 2;
-				y -= mc.fontRenderer.FONT_HEIGHT / 2;
+				x -= mc.fontRendererObj.getStringWidth(this.text) / 2;
+				y -= mc.fontRendererObj.FONT_HEIGHT / 2;
 			}
 			GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-			mc.fontRenderer.drawString(this.text, x, y, this.color, this.drawShadow);
+			mc.fontRendererObj.drawString(this.text, x, y, this.color, this.drawShadow);
 		}
 		super.drawForeground(mouseX, mouseY);
 	}

--- a/java/squeek/speedometer/gui/widget/WidgetTextField.java
+++ b/java/squeek/speedometer/gui/widget/WidgetTextField.java
@@ -12,7 +12,7 @@ public class WidgetTextField extends WidgetBase
 	public WidgetTextField(IGuiHierarchical parent, int x, int y, int w, int h)
 	{
 		super(parent, x, y, w, h);
-		this.textField = new GuiTextField(mc.fontRenderer, getX(), getY(), getWidth(), getHeight());
+		this.textField = new GuiTextField(mc.fontRendererObj, getX(), getY(), getWidth(), getHeight());
 	}
 
 	@Override
@@ -59,7 +59,7 @@ public class WidgetTextField extends WidgetBase
 			// seriously have to recreate the GuiTextField ...
 			if (this.textField != null)
 			{
-				this.textField = new GuiTextField(mc.fontRenderer, x, y, w, h);
+				this.textField = new GuiTextField(mc.fontRendererObj, x, y, w, h);
 			}
 		}
 		super.onGuiEvent(event, source, data);

--- a/java/squeek/speedometer/gui/widget/WidgetTextField.java
+++ b/java/squeek/speedometer/gui/widget/WidgetTextField.java
@@ -12,7 +12,7 @@ public class WidgetTextField extends WidgetBase
 	public WidgetTextField(IGuiHierarchical parent, int x, int y, int w, int h)
 	{
 		super(parent, x, y, w, h);
-		this.textField = new GuiTextField(mc.fontRendererObj, getX(), getY(), getWidth(), getHeight());
+		this.textField = new GuiTextField(0, mc.fontRendererObj, getX(), getY(), getWidth(), getHeight());
 	}
 
 	@Override
@@ -59,7 +59,7 @@ public class WidgetTextField extends WidgetBase
 			// seriously have to recreate the GuiTextField ...
 			if (this.textField != null)
 			{
-				this.textField = new GuiTextField(mc.fontRendererObj, x, y, w, h);
+				this.textField = new GuiTextField(1, mc.fontRendererObj, x, y, w, h);
 			}
 		}
 		super.onGuiEvent(event, source, data);


### PR DESCRIPTION
One method is now called func_175065_a instead of drawstring, this can be reverted after updating to the latest MCP namings.
This update is just to compile with only the forge build updated to the latest RB.
