### PR TITLE
Fix special keys opening menu when key is unbound

### DIFF
--- a/java/squeek/speedometer/SpeedometerKeyHandler.java
+++ b/java/squeek/speedometer/SpeedometerKeyHandler.java
@@ -19,7 +19,7 @@ public class SpeedometerKeyHandler
 	@SubscribeEvent
 	public void onKeyEvent(KeyInputEvent event)
 	{
-		if (Keyboard.getEventKeyState() && Keyboard.getEventKey() == SETTINGS_KEY.getKeyCode())
+		if (SETTINGS_KEY.isPressed())
 		{
 			Minecraft mc = Minecraft.getMinecraft();
 


### PR DESCRIPTION
Makes macro and media keys not open the menu if key isn't bound